### PR TITLE
fix: restore missing drag handle class on GridTile

### DIFF
--- a/packages/module/src/WidgetLayout/GridTile.tsx
+++ b/packages/module/src/WidgetLayout/GridTile.tsx
@@ -164,7 +164,7 @@ const GridTile = ({
             analytics?.('widget-layout.widget-move', { widgetType });
           }}
           onMouseUp={() => setIsDragging(false)}
-          className={clsx({
+          className={clsx('pf-v6-widget-drag-handle', {
             'pf-v6-widget-drag-handle--dragging': isDragging,
           })}
         >


### PR DESCRIPTION
The pf-v6-widget-drag-handle base class was accidentally dropped during the class name refactoring, preventing react-grid-layout from finding the drag handle element.